### PR TITLE
Update btusb.c

### DIFF
--- a/drivers/bluetooth/btusb.c
+++ b/drivers/bluetooth/btusb.c
@@ -37,13 +37,13 @@
 
 #define VERSION "0.6"
 
-static int ignore_dga;
-static int ignore_csr;
-static int ignore_sniffer;
-static int disable_scofix;
-static int force_scofix;
+static bool ignore_dga;
+static bool ignore_csr;
+static bool ignore_sniffer;
+static bool disable_scofix;
+static bool force_scofix;
 
-static int reset = 1;
+static bool reset = true;
 
 static struct usb_driver btusb_driver;
 


### PR DESCRIPTION
in btusb.c around line 1231 theres probably a module_param declaration of ignore_dga as a boolean toggle, but ignore_dga is probably declared near the top of the file as an integer designed for 1 or 0 choices. change it to a bool, so like bool ignore_dga = false; instead of int ignore_dga = 0; for example

Proposed solution by @jcadduono
