### PR TITLE
Update msm_cam_sensor.h

### DIFF
--- a/include/media/msm_cam_sensor.h
+++ b/include/media/msm_cam_sensor.h
@@ -65,11 +65,6 @@ typedef enum sensor_stats_type {
 	YYYY,
 } sensor_stats_type_t;
 
-typedef enum sensor_stats_type {
-	YRGB,
-	YYYY,
-} sensor_stats_type_t;
-
 enum flash_type {
 	LED_FLASH = 1,
 	STROBE_FLASH,


### PR DESCRIPTION
Double typedef enum sensor_stats_type. Deleted of 2 typedef.
